### PR TITLE
Add HydrationSettingsInterface & SingleObjectHydration

### DIFF
--- a/lib/vierbergenlars/Norch/Client.php
+++ b/lib/vierbergenlars/Norch/Client.php
@@ -7,6 +7,7 @@ use vierbergenlars\Norch\SearchQuery\Query;
 use vierbergenlars\Norch\SearchQuery\QueryBuilder;
 use vierbergenlars\Norch\SearchIndex\Index;
 use vierbergenlars\Norch\ODM\DocumentMapper;
+use vierbergenlars\Norch\ODM\HydrationSettingsInterface;
 
 class Client
 {
@@ -46,11 +47,11 @@ class Client
 
     /**
      * Creates a new document mapper
-     * @param string $hydrateObject The object to map the results to
+     * @param \vierbergenlars\Norch\ODM\HydrationSettingsInterface $hydrationSettings
      * @return \vierbergenlars\Norch\ODM\DocumentMapper
      */
-    public function createDocumentMapper($hydrateObject)
+    public function createDocumentMapper(HydrationSettingsInterface $hydrationSettings)
     {
-        return new DocumentMapper($this->transport, $hydrateObject);
+        return new DocumentMapper($this->transport, $hydrationSettings);
     }
 }

--- a/lib/vierbergenlars/Norch/ODM/DocumentMapper.php
+++ b/lib/vierbergenlars/Norch/ODM/DocumentMapper.php
@@ -13,24 +13,20 @@ use vierbergenlars\Norch\SearchQuery\QueryBuilder;
 class DocumentMapper extends Client
 {
     /**
-     * The name of the object to hydrate
-     * @var string
+     * Settings for parameter injection
+     * @var \vierbergenlars\Norch\ODM\HydrationSettingsInterface
      */
-    protected $hydrateObject;
+    protected $hydrationSettings;
 
     /**
      * Creates a new document mapper
      * @param \vierbergenlars\Norch\Transport\TransportInterface $transport The transport to use
-     * @param string $hydrateObject The name of the object to hydrate.
-     *      The object should implement {@link \Defer\Deferrable}
-     * @throws \LogicException
+     * @param \vierbergenlars\Norch\ODM\HydrationSettingsInterface $hydrationSettings
      */
-    public function __construct(TransportInterface $transport, $hydrateObject) {
-        $interfaces = class_implements($hydrateObject);
-        if(!isset($interfaces['Defer\Deferrable']))
-            throw new \LogicException($hydrateObject.' should implement interface \Defer\Deferrable');
-
-        $this->hydrateObject = $hydrateObject;
+    public function __construct(TransportInterface $transport,
+                                HydrationSettingsInterface $hydrationSettings)
+    {
+        $this->hydrationSettings = $hydrationSettings;
         parent::__construct($transport);
     }
 
@@ -39,7 +35,7 @@ class DocumentMapper extends Client
      * @return \vierbergenlars\Norch\SearchQuery\QueryBuilder
      */
     public function createQueryBuilder() {
-        $query = new SearchQuery($this->transport, $this->hydrateObject);
+        $query = new SearchQuery($this->transport, $this->hydrationSettings);
         return new QueryBuilder($query);
     }
 

--- a/lib/vierbergenlars/Norch/ODM/HydrationSettings/SingleObjectHydration.php
+++ b/lib/vierbergenlars/Norch/ODM/HydrationSettings/SingleObjectHydration.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace vierbergenlars\Norch\ODM\HydrationSettings;
+
+use vierbergenlars\Norch\ODM\HydrationSettingsInterface;
+
+/**
+ * A simple hydration strategy that injects all parameters as-is in the object.
+ */
+class SingleObjectHydration implements HydrationSettingsInterface
+{
+    /**
+     * The class name of the object that will be injected
+     * @var string
+     */
+    protected $className;
+
+    /**
+     * Creates a new simple hydration strategy
+     * @param string $className The class that will be hydrated (should implement {@link vierbergenlars\Norch\ODM\Indexable})
+     * @throws \LogicException
+     */
+    public function __construct($className)
+    {
+        $interfaces = class_implements($className);
+        if (!isset($interfaces['vierbergenlars\Norch\ODM\Indexable']))
+            throw new \LogicException($className . ' should implement interface vierbergenlars\Norch\ODM\Indexable');
+        $this->className = $className;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal
+     */
+    public function getClass(array $document)
+    {
+        return $this->className;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal
+     */
+    public function getParameters(array $document)
+    {
+        return $document;
+    }
+
+}

--- a/lib/vierbergenlars/Norch/ODM/HydrationSettingsInterface.php
+++ b/lib/vierbergenlars/Norch/ODM/HydrationSettingsInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace vierbergenlars\Norch\ODM;
+
+/**
+ * Interface for settings for the hydration of search results in objects
+ */
+interface HydrationSettingsInterface
+{
+
+    /**
+     * Gets the properties to be injected in the object
+     * @param array $document The document received from the search query
+     * @return array A map of object properties to values
+     */
+    public function getParameters(array $document);
+
+    /**
+     * Gets the class name of the object that will be hydrated
+     * @param array $document The document received from the search query
+     * @return string A fully qualified class name. (Should implement {@link vierbergenlars\Norch\ODM\Indexable})
+     */
+    public function getClass(array $document);
+}

--- a/lib/vierbergenlars/Norch/ODM/SearchHit.php
+++ b/lib/vierbergenlars/Norch/ODM/SearchHit.php
@@ -3,6 +3,7 @@
 namespace vierbergenlars\Norch\ODM;
 
 use vierbergenlars\Norch\SearchResult\Hit;
+use vierbergenlars\Norch\ODM\HydrationSettingsInterface;
 use Defer\Object as Defer;
 
 /**
@@ -13,14 +14,16 @@ class SearchHit extends Hit
     /**
      * Hydrates the document into an object
      * @internal
-     * @param string $object The name of the object to hydrate to
+     * @param \vierbergenlars\Norch\ODM\HydrationSettingsInterface $hydrationSettings
      */
-    public function hydrateObject($object)
+    public function hydrate(HydrationSettingsInterface $hydrationSettings)
     {
         array_walk($this->document, function(&$field) {
             if(is_array($field))
                 $field = new \ArrayObject($field);
         });
-        $this->document = Defer::defer($this->getDocument(), $object);
+        $document = $hydrationSettings->getParameters($this->document);
+        $class = $hydrationSettings->getClass($this->document);
+        $this->document = Defer::defer($document, $class);
     }
 }

--- a/lib/vierbergenlars/Norch/ODM/SearchQuery.php
+++ b/lib/vierbergenlars/Norch/ODM/SearchQuery.php
@@ -14,22 +14,24 @@ class SearchQuery extends Query
     protected $searchResultClass = '\vierbergenlars\Norch\ODM\SearchResult';
 
     /**
-     * The object to hydrate
-     * @var string
+     * Settings for object hydration
+     * @var \vierbergenlars\Norch\ODM\HydrationSettingsInterface
      */
-    protected $hydrateObject;
+    protected $hydrationSettings;
 
     /**
      * Creates a new search query
      *
      * @internal
      * @param \vierbergenlars\Norch\Transport\TransportInterface $transport
-     * @param string $hydrateObject The name of the object to hydrate, and should implement \Defer\Deferrable
+     * @param \vierbergenlars\Norch\ODM\HydrationSettingsInterface $hydrationSettings
      * @param string $query
      */
-    public function __construct(TransportInterface $transport, $hydrateObject, $query = '')
+    public function __construct(TransportInterface $transport,
+                                HydrationSettingsInterface $hydrationSettings,
+                                $query = '')
     {
-        $this->hydrateObject = $hydrateObject;
+        $this->hydrationSettings = $hydrationSettings;
         parent::__construct($transport, $query);
     }
 
@@ -40,7 +42,7 @@ class SearchQuery extends Query
      */
     public function execute() {
         $searchResult = parent::execute();
-        $searchResult->hydrateObject($this->hydrateObject);
+        $searchResult->hydrate($this->hydrationSettings);
         return $searchResult;
     }
 }

--- a/lib/vierbergenlars/Norch/ODM/SearchResult.php
+++ b/lib/vierbergenlars/Norch/ODM/SearchResult.php
@@ -3,6 +3,7 @@
 namespace vierbergenlars\Norch\ODM;
 
 use vierbergenlars\Norch\SearchResult\SearchResult as Result;
+use vierbergenlars\Norch\ODM\HydrationSettingsInterface;
 
 /**
  * A hydrateable search result
@@ -14,11 +15,11 @@ class SearchResult extends Result
     /**
      * Hydrates all results into objects
      * @internal
-     * @param string $object The name of the object to hydrate into
+     * @param \vierbergenlars\Norch\ODM\HydrationSettingsInterface $hydrationSettings
      */
-    public function hydrateObject($object)
+    public function hydrate(HydrationSettingsInterface $hydrationSettings)
     {
         foreach($this as $hit)
-            $hit->hydrateObject($object);
+            $hit->hydrate($hydrationSettings);
     }
 }

--- a/test/client.php
+++ b/test/client.php
@@ -3,6 +3,7 @@
 namespace test;
 
 use vierbergenlars\Norch\Client as NorchClient;
+use vierbergenlars\Norch\ODM\HydrationSettings\SingleObjectHydration;
 
 class client extends \UnitTestCase
 {
@@ -26,8 +27,10 @@ class client extends \UnitTestCase
     function testCreateDocumentMapper()
     {
         $transport = new searchquery\TransportMock;
+        $hydrationSettings = new SingleObjectHydration('test\odm\DocumentObject');
         $client = new NorchClient($transport);
 
-        $this->assertIsA($client->createDocumentMapper(__NAMESPACE__.'\odm\DocumentObject'), 'vierbergenlars\Norch\ODM\DocumentMapper');
+        $this->assertIsA($client->createDocumentMapper($hydrationSettings),
+                                                       'vierbergenlars\Norch\ODM\DocumentMapper');
     }
 }

--- a/test/odm/documentmapper.php
+++ b/test/odm/documentmapper.php
@@ -3,6 +3,7 @@
 namespace test\odm;
 
 use vierbergenlars\Norch\ODM\DocumentMapper as DM;
+use vierbergenlars\Norch\ODM\HydrationSettings\SingleObjectHydration;
 use test\searchquery\TransportMock;
 
 class documentmapper extends \UnitTestCase
@@ -10,7 +11,8 @@ class documentmapper extends \UnitTestCase
     function testDocumentMapper()
     {
         $transport = new TransportMock;
-        $dm = new DM($transport, __NAMESPACE__.'\DocumentObject');
+        $hydationSettings = new SingleObjectHydration(__NAMESPACE__ . '\DocumentObject');
+        $dm = new DM($transport, $hydationSettings);
 
 
         $query = $dm->createQueryBuilder()->getQuery();

--- a/test/odm/searchhit.php
+++ b/test/odm/searchhit.php
@@ -3,6 +3,7 @@
 namespace test\odm;
 
 use vierbergenlars\Norch\ODM\SearchHit as Hit;
+use vierbergenlars\Norch\ODM\HydrationSettings\SingleObjectHydration;
 
 class searchhit extends \UnitTestCase
 {
@@ -27,8 +28,9 @@ class searchhit extends \UnitTestCase
         );
 
         $hit = new Hit($document);
+        $hydationSettings = new SingleObjectHydration(__NAMESPACE__ . '\DocumentObject');
 
-        $hit->hydrateObject(__NAMESPACE__.'\DocumentObject');
+        $hit->hydrate($hydationSettings);
 
         $this->assertIsA($hit->getDocument(), __NAMESPACE__.'\DocumentObject');
         $doc = $hit->getDocument();

--- a/test/odm/searchquery.php
+++ b/test/odm/searchquery.php
@@ -3,6 +3,7 @@
 namespace test\odm;
 
 use vierbergenlars\Norch\ODM\SearchQuery as Query;
+use vierbergenlars\Norch\ODM\HydrationSettings\SingleObjectHydration;
 use test\searchquery\TransportMock;
 
 class searchquery extends \UnitTestCase
@@ -10,8 +11,9 @@ class searchquery extends \UnitTestCase
     function testSearchQuery()
     {
         $transport = new TransportMock;
+        $hydationSettings = new SingleObjectHydration(__NAMESPACE__ . '\DocumentObject');
 
-        $query = new Query($transport, __NAMESPACE__.'\DocumentObject');
+        $query = new Query($transport, $hydationSettings);
         $result = $query->execute();
 
         $this->assertIsA($result, 'vierbergenlars\Norch\ODM\SearchResult');

--- a/test/odm/searchresult.php
+++ b/test/odm/searchresult.php
@@ -3,6 +3,7 @@
 namespace test\odm;
 
 use vierbergenlars\Norch\ODM\SearchResult as Result;
+use vierbergenlars\Norch\ODM\HydrationSettings\SingleObjectHydration;
 
 class searchresult extends \UnitTestCase
 {
@@ -73,8 +74,9 @@ class searchresult extends \UnitTestCase
 }', true);
 
         $result = new Result($result_array);
+        $hydationSettings = new SingleObjectHydration(__NAMESPACE__ . '\DocumentObject');
 
-        $result->hydrateObject(__NAMESPACE__.'\DocumentObject');
+        $result->hydrate($hydationSettings);
 
         foreach($result as $hit)
         {


### PR DESCRIPTION
Give the user more control about how objects are hydrated.
Hydration parameters and hydration object can be created from the
document that was returned by the search.

Add a simple SingleObjectHydration class to cover the original
functionality
