### PR TITLE
Documents id is passed within the document

### DIFF
--- a/lib/vierbergenlars/Norch/ODM/Indexable.php
+++ b/lib/vierbergenlars/Norch/ODM/Indexable.php
@@ -10,14 +10,8 @@ use Defer\Deferrable;
 interface Indexable extends Deferrable
 {
     /**
-     * Gets the id of the document.
-     * @return string|int An unique identifier of the document
-     */
-    public function getId();
-
-    /**
      * Converts the object to a document.
-     * @return array The returned array should contain a mapping from fields to their values. It should not contain an id key.
+     * @return array The returned array should contain a mapping from fields to their values. It should also contain an id key.
      */
     public function toDocument();
 }

--- a/lib/vierbergenlars/Norch/ODM/SearchIndex.php
+++ b/lib/vierbergenlars/Norch/ODM/SearchIndex.php
@@ -15,7 +15,10 @@ class SearchIndex extends Index
      * @param \vierbergenlars\Norch\ODM\Indexable $document
      * @return \vierbergenlars\Norch\ODM\SearchIndex
      */
-    public function addDocument(Indexable $document) {
+    public function addDocument($document)
+    {
+        if (!($document instanceof Indexable))
+            throw new \BadMethodCallException('Parameter 1 of ' . __METHOD__ . ' should be Indexable, ' . (is_object($document) ? get_class($document) : gettype($document)) . ' given.');
         parent::addDocument($document->toDocument());
         return $this;
     }

--- a/lib/vierbergenlars/Norch/ODM/SearchIndex.php
+++ b/lib/vierbergenlars/Norch/ODM/SearchIndex.php
@@ -16,7 +16,7 @@ class SearchIndex extends Index
      * @return \vierbergenlars\Norch\ODM\SearchIndex
      */
     public function addDocument(Indexable $document) {
-        parent::addDocument($document->getId(), $document->toDocument());
+        parent::addDocument($document->toDocument());
         return $this;
     }
 

--- a/lib/vierbergenlars/Norch/SearchIndex/Index.php
+++ b/lib/vierbergenlars/Norch/SearchIndex/Index.php
@@ -75,8 +75,10 @@ class Index
      * @param array $document Should contain a parameter 'id', that will be used as an id
      * @return \vierbergenlars\Norch\SearchIndex\Index
      */
-    public function addDocument(array $document)
+    public function addDocument($document)
     {
+        if (!is_array($document))
+            throw new \BadMethodCallException('Parameter 1 of ' . __METHOD__ . ' should be array, ' . (is_object($document) ? get_class($document) : gettype($document)) . ' given.');
         $id = $document['id'];
         unset($document['id']);
         unset($this->removedDocuments[$id]);

--- a/lib/vierbergenlars/Norch/SearchIndex/Index.php
+++ b/lib/vierbergenlars/Norch/SearchIndex/Index.php
@@ -41,8 +41,8 @@ class Index
      */
     public function __construct(TransportInterface $transport, array $documents = array(), array $facetFields = array())
     {
-        foreach($documents as $id=>$document)
-            $this->addDocument($id, $document);
+        foreach($documents as $document)
+            $this->addDocument($document);
         foreach($facetFields as $field)
             $this->addFacetField ($field);
         $this->transport = $transport;
@@ -72,12 +72,13 @@ class Index
 
     /**
      * Adds a new document to the index
-     * @param int|string $id The id of the document
-     * @param array $document
+     * @param array $document Should contain a parameter 'id', that will be used as an id
      * @return \vierbergenlars\Norch\SearchIndex\Index
      */
-    public function addDocument($id, $document)
+    public function addDocument(array $document)
     {
+        $id = $document['id'];
+        unset($document['id']);
         unset($this->removedDocuments[$id]);
         $this->uploadedDocuments[$id] = $document;
         return $this;

--- a/test/odm/DocumentObject.php
+++ b/test/odm/DocumentObject.php
@@ -52,7 +52,8 @@ class DocumentObject implements Indexable
     }
 
     public function toDocument() {
-        return array(
+        return array (
+            'id' => $this->id,
             'title'=>  $this->title,
             'body'=>  $this->body,
             'categories'=>  $this->categories->getArrayCopy()

--- a/test/searchindex/index.php
+++ b/test/searchindex/index.php
@@ -10,11 +10,14 @@ class index extends \UnitTestCase
     {
         $transport = new TransportMock;
         $index = new SearchIndex($transport, array(
-            'doc1'=>array('title'=>'a', 'body'=>'b', 'categories'=>array('a','b')),
-            'doc2'=>array('title'=>'b', 'body'=>'c', 'categories'=>array('b','c'))
-        ), array('categories', 'body'));
+            array ('id' => 'doc1', 'title' => 'a', 'body' => 'b', 'categories' => array (
+                    'a', 'b')),
+            array ('id' => 'doc2', 'title' => 'b', 'body' => 'c', 'categories' => array (
+                    'b', 'c'))
+                ), array('categories', 'body'));
 
-        $index->addDocument('doc3', array('title'=>'c', 'body'=>'asdfasdf', 'categories'=> array('c', 'a', 'd')))
+        $index->addDocument(array ('id' => 'doc3', 'title' => 'c', 'body' => 'asdfasdf',
+                    'categories' => array ('c', 'a', 'd')))
                 ->addFacetField('title')
                 ->removeFacetField('body');
 
@@ -58,17 +61,17 @@ class index extends \UnitTestCase
         $transport = new TransportMock;
         $index = new SearchIndex($transport);
 
-        $index->addDocument(1, array('title'=>'a'))
-                ->addDocument(2, array('title'=>'b'))
-                ->addDocument(3, array('title'=>'c'))
-                ->addDocument(4, array('title'=>'d'));
+        $index->addDocument(array ('id' => 1, 'title' => 'a'))
+                ->addDocument(array ('id' => 2, 'title' => 'b'))
+                ->addDocument(array ('id' => 3, 'title' => 'c'))
+                ->addDocument(array ('id' => 4, 'title' => 'd'));
 
         $index->removeDocument(2)
                 ->removeDocument(4)
                 ->removeDocument(5)
                 ->removeDocument(6);
 
-        $index->addDocument(5, array('title'=>'e'));
+        $index->addDocument(array ('id' => 5, 'title' => 'e'));
 
         $status = $index->flush();
 


### PR DESCRIPTION
Removes need for `Indexable::getId()` completely.
